### PR TITLE
Fix removal of all non-filename characters

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -609,7 +609,7 @@ function loadJSONForGenerator(){
 
 function getNameForCurrentImage(ext){
 	var text = document.querySelector("textarea#sourcetext").value
-	text = text.replace(/\n/," ").replace(/[^-._a-zA-Z0-9 ]/,"")
+	text = text.replace(/\n/g," ").replace(/[^-._a-zA-Z0-9 ]/g,"")
 	return selectedGenerator + "-" + text + "." + ext
 }
 


### PR DESCRIPTION
This was causing anything with two lines or two of the right kind of bad character to download the image as "example.com" in Safari.