### PR TITLE
Fix Wally Bear and the NO! Gang test

### DIFF
--- a/games/wally/tests/_default.json
+++ b/games/wally/tests/_default.json
@@ -1,1 +1,1 @@
-{"talking": "Toby", "main-text": "Taking drugs is stupid,\nToby.", "background": "toby-turtle"}
+{"talking": "Wally", "main-text": "Taking drugs is stupid,\nToby.", "background": "toby-turtle"}


### PR DESCRIPTION
The `Wally Bear and the NO! Gang` test had an incorrect "talking" property specified, which resulted in the following error (which also prevented subsequent tests from running) - similar to #32:
```
UnhandledPromiseRejectionWarning: Error: Evaluation failed: TypeError: Cannot read property 'w' of undefined
    at parseOverlays (file:///home/paul/src/SierraDeathGenerator/js/scripts.js:584:14)
```