### PR TITLE
Update .gitignore to ignore thumbs.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 inprogress
+Thumbs.db


### PR DESCRIPTION
Windows generates `Thumbs.db` files but these aren't ignored yet.

Very useful pull request.