### PR TITLE
Add URL query parameter support for shareable pre-filled links

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -687,8 +687,14 @@ function selectGenerator(){
 
 	var sourcetext = $('#sourcetext');
 
-	if(sourcetext.text().length==0 || isAnyDefaultText(sourcetext.text())){
-		$('#sourcetext').text(gen.defaulttext)
+	// Check for text passed via URL query parameter
+	var params = new URLSearchParams(window.location.search);
+	var textParam = params.get('text');
+
+	if(textParam){
+		$('#sourcetext').val(textParam)
+	}else if(sourcetext.val().length==0 || isAnyDefaultText(sourcetext.val())){
+		$('#sourcetext').val(gen.defaulttext)
 	}
 
 	$('#throbber').hide()


### PR DESCRIPTION
## Summary

This PR adds support for passing custom text to generators via URL query parameters, enabling shareable links with pre-filled quotes.

**Example usage:**
```
https://example.com/?text=Your%20custom%20message#bsod
https://example.com/?text=It%27s%20dangerous%20to%20go%20alone.%0A%0AIt%27s%20dangerous%20to%20go%0Aat%20all.#zelda
```

## Motivation

From the README:

> Two commonly asked questions are "Does the death generator have an API?" and "Can I easily run it from the command line?" and the answer to both questions is no. Both are on the to-do list but can't really be done with the current design.

This feature doesn't solve the full API/CLI problem (that would still require the canvas refactoring you mentioned), but it addresses a common subset of the "API" use case: **sharing a specific generator with specific text**.

Users can now:
- Share direct links to specific generators with custom text pre-filled
- Bookmark favorite quotes
- Embed links in tweets/posts that open directly to the desired output
- Build simple integrations that generate URLs (even if rendering still requires a browser)

It's a lightweight win that works within the current static HTML design.

## Implementation

- Added 6 lines to `selectGenerator()` in `js/scripts.js`
- Uses standard `URLSearchParams` API to read the `text` query parameter
- Text parameter takes priority over default text
- Fully backwards compatible — existing URLs without `?text=` work exactly as before
- Supports all existing text features including formatting tags like `[inverse]...[/]`, newlines (`%0A`), etc.

## Test plan

- [x] Tested with BSOD generator including `[inverse]` formatting tags
- [x] Tested with Doom, Zelda, Pokemon, Space Quest 3 generators
- [x] Verified multi-line text works with URL-encoded newlines
- [x] Verified existing URLs without query params still work
- [x] Verified user can still edit text after loading from URL